### PR TITLE
Update upnpc.c

### DIFF
--- a/external/miniupnpc/upnpc.c
+++ b/external/miniupnpc/upnpc.c
@@ -112,7 +112,7 @@ static void ListRedirections(struct UPNPUrls * urls,
                              struct IGDdatas * data)
 {
 	int r;
-	int i = 0;
+	unsigned int i = 0;
 	char index[6];
 	char intClient[40];
 	char intPort[6];


### PR DESCRIPTION
Error when compiling:  

> ./upnpc.c:130:23: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 6 [-Werror=format-truncation=]