### PR TITLE
Update SwappedMap.h

### DIFF
--- a/src/CryptoNoteCore/SwappedMap.h
+++ b/src/CryptoNoteCore/SwappedMap.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <cstdint>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
Error when compiling: 

> ./SwappedMap.h:186:8: error: ‘cout’ is not a member of ‘std’