### PR TITLE
Update hash-extra-jh.c

### DIFF
--- a/src/crypto/hash-extra-jh.c
+++ b/src/crypto/hash-extra-jh.c
@@ -12,6 +12,5 @@
 #include "hash-ops.h"
 
 void hash_extra_jh(const void *data, size_t length, char *hash) {
-  int r = jh_hash(HASH_SIZE * 8, data, 8 * length, (uint8_t*)hash);
-  assert(SUCCESS == r);
+  assert(SUCCESS == jh_hash(HASH_SIZE * 8, data, 8 * length, (uint8_t*)hash));
 }


### PR DESCRIPTION
Compiler warning: unused variable ‘r’ [-Wunused-variable]